### PR TITLE
add infotext

### DIFF
--- a/old_sd_firstpasser/tools.py
+++ b/old_sd_firstpasser/tools.py
@@ -1,9 +1,10 @@
 import math
-from modules import shared
+from modules import shared, sd_models
 from modules.processing import Processed, StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img
 
 
 IS_WEBUI_1_9 = hasattr(shared.cmd_opts, 'unix_filenames_sanitization')
+quote_swap = str.maketrans('\'"', '"\'')
 
 
 def limiSizeByOneDemention(size: tuple, limit: int):
@@ -77,7 +78,7 @@ def convert_txt2img_to_img2img(txt2img: StableDiffusionProcessingTxt2Img) -> Sta
     img2img = StableDiffusionProcessingImg2Img(**txt2imgKWArgs, **img2imgArgs)
 
     otherArgs = ['seed', 'subseed', 'subseed_strength', 'refiner_checkpoint', 'refiner_checkpoint',
-        'refiner_switch_at', 'seed_resize_from_h', 'seed_resize_from_w']
+        'refiner_switch_at', 'seed_resize_from_h', 'seed_resize_from_w', 'extra_generation_params']
 
     for arg in otherArgs:
         value = getattr(txt2img, arg, None)
@@ -105,3 +106,7 @@ def removeAllNetworksWithErrorsWarnings(processed: Processed):
 NAME = "Old SD firstpasser"
 
 
+def get_model_short_title(model_aliases):
+    if model := sd_models.get_closet_checkpoint_match(model_aliases):
+        return model.short_title
+    return model_aliases

--- a/old_sd_firstpasser/ui.py
+++ b/old_sd_firstpasser/ui.py
@@ -1,8 +1,10 @@
+import json
 import gradio as gr
 from modules import ui_settings, shared
+from old_sd_firstpasser.tools import quote_swap
 
 
-def makeUI():
+def makeUI(script):
     with gr.Row():
         firstpass_steps = gr.Slider(
             label='Firstpass steps',
@@ -27,5 +29,22 @@ def makeUI():
         sd_1_checkpoint = ui_settings.create_setting_component('sd_model_checkpoint')
         sd_1_checkpoint.label = "Checkpoint for SD 1.x pass"
 
+    def get_infotext_field(d, field):
+        if 'Old SD firstpasser' in d:
+            return d['Old SD firstpasser'].get(field)
+
+    script.infotext_fields = [
+        (firstpass_steps, lambda d: get_infotext_field(d, 'steps')),
+        (firstpass_denoising, lambda d: get_infotext_field(d, 'denoising')),
+        (firstpass_upscaler, lambda d: get_infotext_field(d, 'upscaler')),
+        (sd_1_checkpoint, lambda d: get_infotext_field(d, 'model')),
+    ]
+
     return [firstpass_steps, firstpass_denoising, firstpass_upscaler, sd_1_checkpoint]
 
+
+def pares_infotext(infotext, params):
+    try:
+        params['Old SD firstpasser'] = json.loads(params['Old SD firstpasser'].translate(quote_swap))
+    except Exception:
+        pass

--- a/scripts/old_sd_firstpasser_img2img.py
+++ b/scripts/old_sd_firstpasser_img2img.py
@@ -1,12 +1,13 @@
 import copy
 from contextlib import closing
-import gradio as gr
+import json
 from PIL import Image
-from modules import shared, scripts_postprocessing, scripts, sd_models, processing
+from modules import shared, scripts_postprocessing, scripts, sd_models
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
 
-from old_sd_firstpasser.tools import ( limiSizeByOneDemention, getJobsCountImg2Img,
-    getTotalStepsImg2Img, removeAllNetworksWithErrorsWarnings, NAME, getSecondPassBeginFromImg2Img,
+from old_sd_firstpasser.tools import (
+    limiSizeByOneDemention, getJobsCountImg2Img, getTotalStepsImg2Img, removeAllNetworksWithErrorsWarnings, NAME,
+    getSecondPassBeginFromImg2Img, quote_swap, get_model_short_title,
 )
 from old_sd_firstpasser.ui import makeUI
 if hasattr(scripts_postprocessing.ScriptPostprocessing, 'process_firstpass'):  # webui >= 1.7
@@ -32,7 +33,7 @@ class ScriptSelectable(scripts.Script):
         return is_img2img
 
     def ui(self, is_img2img):
-        ui = makeUI()
+        ui = makeUI(self)
         return ui
 
 
@@ -46,12 +47,19 @@ class ScriptSelectable(scripts.Script):
 
             originalP.do_not_save_grid = True
 
+            originalP.extra_generation_params['Script'] = NAME
+            originalP.extra_generation_params['Old SD firstpasser'] = json.dumps({
+                'steps': firstpass_steps,
+                'denoising': firstpass_denoising,
+                'upscaler': firstpass_upscaler,
+                'model': get_model_short_title(sd_1_checkpoint),
+            }).translate(quote_swap)
+
             img2imgP = copy.copy(originalP)
             img2imgP.width, img2imgP.height = limiSizeByOneDemention((originalP.width, originalP.height), 512)
             img2imgP.steps = firstpass_steps
             img2imgP.batch_size = 1
             img2imgP.n_iter = 1
-    
 
             if originalP.init_images or not all(originalP.init_images): # txt2img equivalent
                 dummy_image = Image.new('RGB', (originalP.width, originalP.height))


### PR DESCRIPTION
- as mentioned in https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/296#issuecomment-2039505381
you forgot about infotext

infotext / png-info it's important part of web UI as it allows the user to recreate the image after words

this PR add infotext and
when the infotext is read by webui switch to the script and populate the scripts you are with the one specified in the info text

![image](https://github.com/light-and-ray/sd-webui-old-sd-firstpasser/assets/40751091/549bafcd-3a47-4685-9d16-a755a3c04c84)

the info text is written in the form of "quote swapped json dict" under the key "Old SD firstpasser"

---

during development of this I found that you have two issues

1. vae in override, it will create image with strange colors
2. when seed `-1` (random), I belive what's happening is that the seed used across different passes of image gen is random and not recorded in infotext, as such the information is lost and you won't be able to recreate the image

